### PR TITLE
Add /prompt skill and index.md

### DIFF
--- a/.claude/commands/prompt.md
+++ b/.claude/commands/prompt.md
@@ -1,0 +1,77 @@
+---
+description: Compile a raw request into a structured, intent-preserving prompt plus a base plan, with a token-discipline pass (runs in a cheap subagent)
+argument-hint: "[what you want, in plain words]"
+---
+
+Treat the user's words as **raw intent**, not a finished instruction. The compilation itself runs in a **subagent** so it doesn't burn main-thread context; your job here is to dispatch it, then relay the result.
+
+The raw intent is: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, use the user's most recent message as the intent; if that's also unclear, ask them what they want compiled and stop — don't spawn a subagent for nothing.
+
+## Dispatch — run the compilation in a subagent
+
+Spawn **one** `Agent` with these rule parameters:
+
+- `subagent_type`: `general-purpose`
+- `model`: **`haiku`** — this is a lightweight rewriting task; Haiku 4.5 is the cost fit. Do **not** use `sonnet` (Sonnet 5) or `opus` for a routine compile — that's the token waste this rule exists to prevent. Only escalate to `sonnet` if the raw intent is itself large or highly technical (e.g. a multi-part spec), and say so when you do.
+- `run_in_background`: `false` — you need the compiled prompt before you can continue.
+- `prompt`: the raw intent above, followed verbatim by everything under **"Compilation task"** below.
+
+The subagent's final report is not shown to the user. When it returns, **relay its three-section output verbatim** to the user, then ask: **"Run this now, or do you want to edit it first?"** Do not start executing the compiled prompt until the user says to.
+
+If a critical piece of context is missing, the subagent will flag it under *Assumptions & notes* rather than blocking — surface that to the user, but still show the compiled prompt.
+
+---
+
+## Compilation task
+
+*(This is the subagent's instruction set. Compile the raw intent into a ready-to-run prompt + base plan. Preserve meaning; do not solve a cleaner adjacent problem — that's intent drift. Prefer stating explicit assumptions over asking questions, since you can't talk to the user directly.)*
+
+### Step 1 — extract intent (preserve, never replace)
+
+- **Objective** — the single outcome that means "done."
+- **Given context** — constraints, environment, prior decisions already stated.
+- **Missing context** — what a competent stranger would need but wasn't said.
+
+The compiled prompt must be losslessly re-derivable from what was actually asked. If a *critical* piece of context is missing (something that changes the answer), pick the safest default, proceed, and record it under *Assumptions & notes* — do not block.
+
+### Step 2 — compile against the quality checklist
+
+Include, in this order, only the parts that apply:
+
+1. **Role + objective** — one sentence: who the model acts as, and the outcome that defines done.
+2. **Context the model can't infer** — constraints, environment, prior decisions. Not backstory it already knows.
+3. **Output contract** — format, length, what to include/exclude. Biggest quality lever; always include it.
+4. **Success criteria** — how the user would check it's right.
+5. **Scope boundaries** — what NOT to do, so the model doesn't over-deliver.
+6. **Reasoning instruction** — ask for reasoning-before-answer only when the task is non-trivial.
+
+### Step 3 — token-discipline pass
+
+Target **total tokens to a correct result across the whole exchange**, not the shortest first message. In priority order:
+
+1. **Structure over prose** — bullets, tables, labeled fields.
+2. **Cut ritual, not content** — drop filler; never cut a constraint, example, or success criterion to save tokens (that causes a re-do — a whole extra turn).
+3. **One canonical statement per fact** — remove repetition.
+4. **Reference, don't restate** — point at a file/section instead of pasting it.
+5. **Right-size reasoning** — no scratchpad on trivial tasks.
+
+### Step 4 — base plan
+
+A short ordered plan (3–7 steps) for executing the compiled prompt, so the run doesn't wander.
+
+### Step 5 — output
+
+Return exactly three sections, nothing else:
+
+```
+## Compiled prompt
+<the ready-to-run prompt from Steps 2–3>
+
+## Base plan
+<the ordered steps from Step 4>
+
+## Assumptions & notes
+<assumptions made, intent preserved, or critical clarifications for the user — omit if none>
+```

--- a/.notes/index.md
+++ b/.notes/index.md
@@ -1,0 +1,14 @@
+# Private notes — ai-skill
+
+This folder is **gitignored** (see `.gitignore`). Nothing here is published even though the repo is public. Safe for half-formed ideas, design rationale, and TODOs.
+
+Open this folder directly as an Obsidian vault if you want backlinks/graph — Obsidian only needs a folder of markdown, no commit required.
+
+## How knowledge is split
+- **Here (`.notes/`)** — private, this-project dev notes. Local only.
+- **Claude Code memory** (`~/.claude/projects/<this-repo>/memory/`) — durable cross-session facts Claude recalls automatically. Private to you.
+- **Public repo** — only things worth shipping: commands, prompts, README.
+- **`.claude/cr/`** — runtime state (codebase map, learned notes) when the commands run *against a target repo*. Gitignored here so our own runs don't leak.
+
+## Ideas parking lot
+- [ ] (add freely — nothing here ships)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-codereviewer-skill
 
-Slash commands for running parallel, severity-ranked code reviews and turning the results into fixed, PR'd code.
+A small collection of portable AI skills — parallel severity-ranked code review, turning the results into fixed PR'd code, and compiling raw requests into structured prompts.
 
 - **Claude Code users:** use `.claude/commands/` — `/cr-run` and `/cr-fix` work out of the box with auto-discovery.
 - **Any other tool** (Cursor, Aider, Codex, ChatGPT, etc.): use the plain-text prompts in [`prompts/`](prompts/) — copy-paste `prompts/cr-run.md` or `prompts/cr-fix.md`, filling in the `{{LEVEL}}` / `{{ISSUES}}` placeholder, into your tool of choice. Same logic, no Claude Code-specific syntax.
@@ -31,6 +31,16 @@ After reporting findings, Claude asks whether to file them as GitHub issues via 
 ```
 /cr-run
 /cr-run high
+```
+
+### `/prompt [what you want, in plain words]`
+
+Compiles a raw request into a ready-to-run prompt plus a base plan, then hands it back for you to run. Treats your words as **intent** and restructures them — without changing what they mean — against a prompt-quality checklist (role/objective, output contract, success criteria, scope boundaries), then runs a token-discipline pass. The compilation runs in a cheap **Haiku subagent** (it's lightweight rewriting, not worth Sonnet/Opus rates) and keeps main-thread context clean. It does not execute the compiled prompt until you say to.
+
+**Usage:**
+```
+/prompt write a script to rename my photos by date taken
+/prompt
 ```
 
 ### `/cr-fix <issue-number(s)|all>`

--- a/prompts/prompt.md
+++ b/prompts/prompt.md
@@ -1,0 +1,71 @@
+# prompt — intent-to-prompt compiler
+
+Portable version of Claude Code's `/prompt` command. Paste this into any coding agent or chat model (Cursor, Aider, Codex, ChatGPT, etc.) and replace `{{INTENT}}` with what you want, in plain words.
+
+---
+
+Treat the text in `{{INTENT}}` as **raw intent**, not a finished instruction. Compile it into a clean, structured prompt and a base plan — the way a compiler turns source into an efficient runnable form **without changing what it means** — then hand it back to be run.
+
+Raw intent: `{{INTENT}}`
+
+If `{{INTENT}}` is empty or unclear, ask what should be compiled and stop.
+
+## Where to run the compilation
+
+If your tool supports **subagents / sub-sessions with a model choice**, run the compilation task below in one, using the **cheapest capable model** (e.g. Haiku-class) — this is lightweight rewriting, so a top-tier model is a token waste. Only escalate the model if the raw intent is itself large or highly technical. Then relay the subagent's three-section output verbatim.
+
+If your tool has **no subagent concept**, just do the compilation task inline yourself.
+
+Either way, after producing the output, ask: **"Run this now, or do you want to edit it first?"** Do not execute the compiled prompt until told to.
+
+## Compilation task
+
+Preserve meaning; do not solve a cleaner adjacent problem — that's intent drift.
+
+### Step 1 — extract intent (preserve, never replace)
+
+- **Objective** — the single outcome that means "done."
+- **Given context** — constraints, environment, prior decisions already stated.
+- **Missing context** — what a competent stranger would need but wasn't said.
+
+The compiled prompt must be losslessly re-derivable from what was actually asked. If a *critical* piece of context is missing (something that changes the answer), pick the safest default, proceed, and record it under *Assumptions & notes* — don't block.
+
+### Step 2 — compile against the quality checklist
+
+Include, in this order, only the parts that apply:
+
+1. **Role + objective** — one sentence: who the model acts as, and the outcome that defines done.
+2. **Context the model can't infer** — constraints, environment, prior decisions. Not backstory it already knows.
+3. **Output contract** — format, length, what to include/exclude. Biggest quality lever; always include it.
+4. **Success criteria** — how you'd check it's right.
+5. **Scope boundaries** — what NOT to do, so the model doesn't over-deliver.
+6. **Reasoning instruction** — ask for reasoning-before-answer only when the task is non-trivial.
+
+### Step 3 — token-discipline pass
+
+Target **total tokens to a correct result across the whole exchange**, not the shortest first message. In priority order:
+
+1. **Structure over prose** — bullets, tables, labeled fields.
+2. **Cut ritual, not content** — drop filler; never cut a constraint, example, or success criterion to save tokens (that causes a re-do — a whole extra turn).
+3. **One canonical statement per fact** — remove repetition.
+4. **Reference, don't restate** — point at a file/section instead of pasting it.
+5. **Right-size reasoning** — no scratchpad on trivial tasks.
+
+### Step 4 — base plan
+
+A short ordered plan (3–7 steps) for executing the compiled prompt, so the run doesn't wander.
+
+### Step 5 — output
+
+Return exactly three sections, nothing else:
+
+```
+## Compiled prompt
+<the ready-to-run prompt from Steps 2–3>
+
+## Base plan
+<the ordered steps from Step 4>
+
+## Assumptions & notes
+<assumptions made, intent preserved, or critical clarifications for the user — omit if none>
+```


### PR DESCRIPTION
Merges the two latest commits from \`codereview\` into \`main\`:

- **3ad1821** — Add \`/prompt\` skill: intent-to-prompt compiler run in a cheap Haiku subagent (dual-form command + portable prompt, README).
- **ca125e4** — Create index.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)